### PR TITLE
Added integration into wapm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@ build
 tools/build_duktape/duktape/
 tools/build_duktape/out/
 wasi-sdk*
+wapm.lock
+wapm_packages
+.DS_Store

--- a/qjs-wasi/README.md
+++ b/qjs-wasi/README.md
@@ -1,17 +1,26 @@
-# QuickJS on WASI
+# QuickJS
+
+QuickJS is a small and embeddable Javascript engine. It supports the ES2019 specification including modules, asynchronous generators and proxies.
+
+It optionally supports mathematical extensions such as big integers (BigInt), big floating point numbers (BigFloat) and operator overloading.
+
+
+**Original Source**: https://bellard.org/quickjs/quickjs-2019-07-09.tar.xz
+
+**Modification**: We made some changes to adapt the codebase to the [WASI interface](https://wapm.io/interface/wasi).
+
+
+## Running
+
+```bash
+# Run qjs
+wapm run qjs --dir=. --module examples/hello_module.js
+```
 
 ## Building
 
-```
+```bash
 ./build.sh
 ```
 
 It will download the WASI SDK (the macOS version).
-
-## Running
-
-You need to have [wasmtime](https://github.com/CraneStation/wasmtime) installed.
-
-```
-wasmtime --dir examples/ build/qjs.wasm -- --module examples/hello_module.js
-```

--- a/qjs-wasi/wapm.toml
+++ b/qjs-wasi/wapm.toml
@@ -1,0 +1,23 @@
+[package]
+name = "quickjs"
+version = "0.0.1"
+description = "QuickJS is a small and embeddable Javascript engine. It supports the ES2019 specification including modules, asynchronous generators and proxies."
+readme = "README.md"
+repository = "https://github.com/saghul/wasi-lab"
+homepage = "https://bellard.org/quickjs/"
+
+[[module]]
+name = "qjs"
+source = "build/qjs.wasm"
+abi = "wasi"
+
+[module.interfaces]
+wasi = "0.0.0-unstable"
+
+[[command]]
+name = "qjs"
+module = "qjs"
+
+[[command]]
+name = "quickjs"
+module = "qjs"

--- a/wasiduk/README.md
+++ b/wasiduk/README.md
@@ -1,21 +1,26 @@
-# Duktape on WASI
+# Duktape
+
+[Duktape](http://duktape.org/) is an **embeddable Javascript** engine,
+with a focus on **portability** and **compact** footprint.
+
+**Original Source**: https://github.com/svaarala/duktape
+
+**Modification**: We made some changes to adapt the codebase to the [WASI interface](https://wapm.io/interface/wasi).
+
+## Running
+
+```bash
+# Run a file
+wapm run duk --dir=. examples/hello_world.js
+
+# Run the duk shell
+wapm run duk
+```
 
 ## Building
 
-```
+```bash
 ./build.sh
 ```
 
 It will download the WASI SDK (the macOS version).
-
-## Running
-
-You need to have [wasmtime](https://github.com/CraneStation/wasmtime) or [wasmer](https://wasmer.io/) installed.
-
-```
-wasmtime --dir examples/ build/duk.wasm -- examples/hello_world.js
-```
-
-```
-wasmer run --dir=examples/ build/duk.wasm -- examples/hello_world.js
-```

--- a/wasiduk/wapm.toml
+++ b/wasiduk/wapm.toml
@@ -1,0 +1,19 @@
+[package]
+name = "duktape"
+version = "0.0.1"
+description = "Duktape is an embeddable Javascript engine, with a focus on portability and compact footprint."
+readme = "README.md"
+repository = "https://github.com/saghul/wasi-lab"
+homepage = "https://duktape.org/"
+
+[[module]]
+name = "duktape"
+source = "build/duk.wasm"
+abi = "wasi"
+
+[module.interfaces]
+wasi = "0.0.0-unstable"
+
+[[command]]
+name = "duk"
+module = "duktape"


### PR DESCRIPTION
This PR prepares the repo to be publishable into wapm, with an improved README that will help people to install it.

Once it's merged, it can be published easily with:
```
# Register in the wapm.io website
# https://wapm.io/signup

# Login
wapm login

# Publish the package
wapm publish
```

PS: You will need to rename the packages from `quickjs` to `YOUR_USERNAME/quickjs` and similarly for `duktape`.