### PR TITLE
Update SDK to 6.0

### DIFF
--- a/qjs-wasi/README.md
+++ b/qjs-wasi/README.md
@@ -4,48 +4,32 @@ QuickJS is a small and embeddable JavaScript engine. It supports the ES2019 spec
 
 It optionally supports mathematical extensions such as big integers (BigInt), big floating point numbers (BigFloat) and operator overloading.
 
+Install it with:
+
+```bash
+wapm install -g quickjs
+```
+
 **Original Source**: https://bellard.org/quickjs/quickjs-2019-07-09.tar.xz
 
 **Modifications**: We made some changes to adapt the codebase to the [WASI interface](https://wapm.io/interface/wasi).
-
-## Building
-
-```bash
-./build.sh
-```
-
-It will download the WASI SDK (the macOS version).
 
 ## Running
 
 Without any arguments a simple REPL will be launched.
 
-### Using wasmtime
-
 ```bash
 # Run a file
-wasmtime --dir examples/ build/qjs.wasm -- --module examples/hello_module.js
+qjs --dir=. --module examples/hello_module.js
 
 # Run the REPL
-wasmtime --dir . build/qjs.wasm
+qjs
 ```
 
-### Using wasmer (not fully working yet)
+## Building
+
+The following script will download the WASI SDK and build the Wasm binary.
 
 ```bash
-# Run a file
-wasmer run --dir=examples/ build/qjs.wasm -- --module examples/hello_world.js
-
-# Run the REPL
-wasmer run --dir=. build/qjs.wasm
-```
-
-### Using wapm (not available yet)
-
-```bash
-# Run a file
-wapm run qjs --dir=. --module examples/hello_module.js
-
-# Run the REPL
-wapm run qjs
+./build.sh
 ```

--- a/qjs-wasi/build.sh
+++ b/qjs-wasi/build.sh
@@ -1,8 +1,14 @@
 #!/bin/bash
 
-if [[ ! -d wasi-sdk-5.0 ]]; then
-    curl -L -O https://github.com/CraneStation/wasi-sdk/releases/download/wasi-sdk-5/wasi-sdk-5.0-macos.tar.gz
-    tar zxvf wasi-sdk-5.0-macos.tar.gz
+if [[ ! -d wasi-sdk-6.0 ]]; then
+    OS=$(uname | tr '[:upper:]' '[:lower:]')
+    case "$OS" in
+        darwin) WASI_URL='https://github.com/CraneStation/wasi-sdk/releases/download/wasi-sdk-6/wasi-sdk-6.0-macos.tar.gz';;
+        linux) WASI_URL='https://github.com/CraneStation/wasi-sdk/releases/download/wasi-sdk-6/wasi-sdk-6.0-linux.tar.gz';;
+        *) printf "$red> The OS (${OS}) is not supported by this installation script.$reset\n"; exit 1;;
+    esac
+    curl -L -o wasi-sdk-6.0.tar.gz ${WASI_URL}
+    tar zxvf wasi-sdk-6.0.tar.gz
 fi
 
 mkdir -p build

--- a/qjs-wasi/wapm.toml
+++ b/qjs-wasi/wapm.toml
@@ -1,5 +1,5 @@
 [package]
-name = "saghul/quickjs"
+name = "quickjs"
 version = "0.0.1"
 description = "QuickJS is a small and embeddable JavaScript engine. It supports the ES2019 specification including modules, asynchronous generators and proxies."
 readme = "README.md"

--- a/qjs-wasi/wasi-sdk.cmake
+++ b/qjs-wasi/wasi-sdk.cmake
@@ -7,7 +7,7 @@ set(CMAKE_SYSTEM_NAME Wasm)
 set(CMAKE_SYSTEM_VERSION 1)
 set(CMAKE_SYSTEM_PROCESSOR wasm32)
 set(triple wasm32-wasi)
-set(WASI_SDK_PREFIX ${PROJECT_SOURCE_DIR}/wasi-sdk-5.0/opt/wasi-sdk)
+set(WASI_SDK_PREFIX ${PROJECT_SOURCE_DIR}/wasi-sdk-6.0/opt/wasi-sdk)
 
 set(CMAKE_C_COMPILER ${WASI_SDK_PREFIX}/bin/clang)
 set(CMAKE_CXX_COMPILER ${WASI_SDK_PREFIX}/bin/clang++)

--- a/wasiduk/README.md
+++ b/wasiduk/README.md
@@ -3,48 +3,33 @@
 [Duktape](http://duktape.org/) is an **embeddable JavaScript** engine,
 with a focus on **portability** and **compact** footprint.
 
+Install it with:
+
+```bash
+wapm install -g duktape
+```
+
 **Original Source**: https://github.com/svaarala/duktape
 
 **Modifications**: We made some changes to adapt the codebase to the [WASI interface](https://wapm.io/interface/wasi).
-
-## Building
-
-```bash
-./build.sh
-```
-
-It will download the WASI SDK (the macOS version).
 
 ## Running
 
 Without any arguments a simple REPL will be launched.
 
-### Using wasmtime
-
 ```bash
 # Run a file
-wasmtime --dir examples/ build/duk.wasm -- examples/hello_world.js
+duk --dir=. examples/hello_world.js
 
 # Run the REPL
-wasmtime --dir . build/duk.wasm
+duk
 ```
 
-### Using wasmer
+
+## Building
+
+The following script will download the WASI SDK and build the Wasm binary.
 
 ```bash
-# Run a file
-wasmer run --dir=examples/ build/duk.wasm -- examples/hello_world.js
-
-# Run the REPL
-wasmer run --dir=. build/duk.wasm
-```
-
-### Using wapm (not available yet)
-
-```bash
-# Run a file
-wapm run duk --dir=. examples/hello_world.js
-
-# Run the REPL
-wapm run duk
+./build.sh
 ```

--- a/wasiduk/build.sh
+++ b/wasiduk/build.sh
@@ -1,8 +1,14 @@
 #!/bin/bash
 
-if [[ ! -d wasi-sdk-5.0 ]]; then
-    curl -L -O https://github.com/CraneStation/wasi-sdk/releases/download/wasi-sdk-5/wasi-sdk-5.0-macos.tar.gz
-    tar zxvf wasi-sdk-5.0-macos.tar.gz
+if [[ ! -d wasi-sdk-6.0 ]]; then
+    OS=$(uname | tr '[:upper:]' '[:lower:]')
+    case "$OS" in
+        darwin) WASI_URL='https://github.com/CraneStation/wasi-sdk/releases/download/wasi-sdk-6/wasi-sdk-6.0-macos.tar.gz';;
+        linux) WASI_URL='https://github.com/CraneStation/wasi-sdk/releases/download/wasi-sdk-6/wasi-sdk-6.0-linux.tar.gz';;
+        *) printf "$red> The OS (${OS}) is not supported by this installation script.$reset\n"; exit 1;;
+    esac
+    curl -L -o wasi-sdk-6.0.tar.gz ${WASI_URL}
+    tar zxvf wasi-sdk-6.0.tar.gz
 fi
 
 mkdir -p build

--- a/wasiduk/wapm.toml
+++ b/wasiduk/wapm.toml
@@ -1,5 +1,5 @@
 [package]
-name = "saghul/duktape"
+name = "duktape"
 version = "0.0.1"
 description = "Duktape is an embeddable JavaScript engine, with a focus on portability and compact footprint."
 readme = "README.md"

--- a/wasiduk/wasi-sdk.cmake
+++ b/wasiduk/wasi-sdk.cmake
@@ -7,7 +7,7 @@ set(CMAKE_SYSTEM_NAME Wasm)
 set(CMAKE_SYSTEM_VERSION 1)
 set(CMAKE_SYSTEM_PROCESSOR wasm32)
 set(triple wasm32-wasi)
-set(WASI_SDK_PREFIX ${PROJECT_SOURCE_DIR}/wasi-sdk-5.0/opt/wasi-sdk)
+set(WASI_SDK_PREFIX ${PROJECT_SOURCE_DIR}/wasi-sdk-6.0/opt/wasi-sdk)
 
 set(CMAKE_C_COMPILER ${WASI_SDK_PREFIX}/bin/clang)
 set(CMAKE_CXX_COMPILER ${WASI_SDK_PREFIX}/bin/clang++)


### PR DESCRIPTION
This PR:
* Updates the WASI SDK to 6.0
* Updates the packages config (so they are publishable in the global namespace in wapm)
* Updates the READMEs to make it easier to digest in wapm