### PR TITLE
Add online links

### DIFF
--- a/qjs-wasi/README.md
+++ b/qjs-wasi/README.md
@@ -10,9 +10,10 @@ It optionally supports mathematical extensions such as big integers (BigInt), bi
 
 ## Running
 
-### With wasmer
+You can run `quickjs` on your browser:
+https://webassembly.sh/?run-command=qjs
 
-Install it with:
+Or you can run it locally in your shell with:
 
 ```bash
 wapm install -g quickjs

--- a/wasiduk/README.md
+++ b/wasiduk/README.md
@@ -9,9 +9,10 @@ with a focus on **portability** and **compact** footprint.
 
 ## Running
 
-### With wasmer
+You can run `duktape` on your browser:
+https://webassembly.sh/?run-command=duk
 
-Install it with:
+Or you can run it locally in your shell:
 
 ```bash
 wapm install -g duktape


### PR DESCRIPTION
We just [launched WebAssembly.sh](https://medium.com/wasmer/webassembly-sh-408b010c14db), and it automatically exposes all the WAPM WASI modules.

This PR add links to the READMEs so users can try `duktape` and `quickjs` online! 🎉