### PR TITLE
Add build.zig to qjs-wasi project

### DIFF
--- a/qjs-wasi/README.md
+++ b/qjs-wasi/README.md
@@ -43,8 +43,31 @@ wasmtime --dir . build/qjs.wasm
 
 ## Building
 
+### With wasienv
+
 The following script will install [`wasienv`](https://github.com/wasienv/wasienv) and build the Wasm binary.
 
 ```bash
 ./build.sh
 ```
+
+### With Zig
+
+You will need nightly Zig which you can either build from source or download from the official website [here],
+under "master" heading.
+
+[here]: https://ziglang.org/download/
+
+```bash
+zig build
+```
+
+This will cross-compile the project to `wasm32-wasi` by default and build it in Debug mode. If you want to build the
+project in ReleaseFast (ReleaseFast is the equivalent for Release in other build systems), add `-Drelease-fast` option
+to the build invocation.
+
+```bash
+zig build -Drelease-fast
+```
+
+The runnable WASI module can be found in `zig-out/bin/qjs.wasm`.

--- a/qjs-wasi/build.zig
+++ b/qjs-wasi/build.zig
@@ -1,7 +1,13 @@
 const std = @import("std");
 
 pub fn build(b: *std.build.Builder) !void {
-    const target = b.standardTargetOptions(.{});
+    // We will target wasm32-wasi by default.
+    const target = b.standardTargetOptions(.{
+        .default_target = .{
+            .cpu_arch = .wasm32,
+            .os_tag = .wasi,
+        },
+    });
     const mode = b.standardReleaseOptions();
 
     const qjs = b.addExecutable("qjs", null);

--- a/qjs-wasi/build.zig
+++ b/qjs-wasi/build.zig
@@ -1,0 +1,36 @@
+const std = @import("std");
+
+pub fn build(b: *std.build.Builder) !void {
+    const target = b.standardTargetOptions(.{});
+    const mode = b.standardReleaseOptions();
+
+    const qjs = b.addExecutable("qjs", null);
+    qjs.setTarget(target);
+    qjs.setBuildMode(mode);
+    qjs.install();
+    qjs.linkLibC();
+
+    var flags = std.ArrayList([]const u8).init(b.allocator);
+    defer flags.deinit();
+    try flags.appendSlice(&.{
+        "-funsigned-char",
+        "-D_GNU_SOURCE",
+        "-DCONFIG_VERSION=\"2019-07-09\"",
+    });
+
+    if (target.getCpuArch() == .wasm32 and target.getOsTag() == .wasi) {
+        qjs.linkSystemLibrary("wasi-emulated-process-clocks");
+        qjs.linkSystemLibrary("wasi-emulated-signal");
+        try flags.append("-D_WASI_EMULATED_SIGNAL");
+    }
+
+    qjs.addCSourceFiles(&.{
+        "src/cutils.c",
+        "src/libregexp.c",
+        "src/libunicode.c",
+        "src/qjs.c",
+        "src/quickjs-libc.c",
+        "src/quickjs.c",
+        "src/repl.c",
+    }, flags.items);
+}

--- a/qjs-wasi/build.zig
+++ b/qjs-wasi/build.zig
@@ -20,6 +20,7 @@ pub fn build(b: *std.build.Builder) !void {
     defer flags.deinit();
     try flags.appendSlice(&.{
         "-funsigned-char",
+        "-fno-sanitize=undefined", // Delete this line to enable UBSAN in non-ReleaseFast builds.
         "-D_GNU_SOURCE",
         "-DCONFIG_VERSION=\"2019-07-09\"",
     });


### PR DESCRIPTION
This change integrates the project with Zig as a replacement build system to CMake. With this change, you can use Zig to easily cross-compile qjs to WASI:

```
zig build
```

Note that you need latest nightly Zig so that you have access to emulated WASI libc subcomponents such as process clocks and signals.

---

Depends on https://github.com/ziglang/zig/pull/8992

~~Plus I need work out why I'm getting a miscompilation (potentially, mislinking) in Debug/ReleaseSafe and not in ReleaseFast (failed assert converted into UB most likely).~~ See comment below.